### PR TITLE
Add count to pandas API

### DIFF
--- a/docs/user-guide/advanced/Pandas_API.ipynb
+++ b/docs/user-guide/advanced/Pandas_API.ipynb
@@ -2452,6 +2452,41 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Table.count()\n",
+    "\n",
+    "```\n",
+    "Table.count(axis=0, numeric_only=False)\n",
+    "```\n",
+    "\n",
+    "Returns the ount non-NA values across the given axis.\n",
+    "\n",
+    "**Parameters:**\n",
+    "\n",
+    "| Name         | Type | Description                                                                      | Default |\n",
+    "| :----------: | :--: | :------------------------------------------------------------------------------- | :-----: |\n",
+    "| axis         | int  | The axis to calculate the product across 0 is columns, 1 is rows.                | 0       |\n",
+    "| numeric_only | bool | Only use columns of the table that are of a numeric data type.                   | False   |\n",
+    "\n",
+    "**Returns:**\n",
+    "\n",
+    "| Type               | Description                                                          |\n",
+    "| :----------------: | :------------------------------------------------------------------- |\n",
+    "| Dictionary         | A dictionary where the key represent the column name / row number and the values are the result of calling `count` on that column / row. |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tab.count()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "621766f6",
    "metadata": {},
    "source": [

--- a/src/pykx/pandas_api/pandas_meta.py
+++ b/src/pykx/pandas_api/pandas_meta.py
@@ -255,3 +255,8 @@ class PandasMeta:
             res,
             min_count
         ), cols)
+
+    @convert_result
+    def count(self, axis=0, numeric_only=False):
+            res, cols = preparse_computations(self, axis, True, numeric_only)
+            return (q('{[row] count each row}',res), cols)

--- a/tests/test_pandas_api.py
+++ b/tests/test_pandas_api.py
@@ -2029,3 +2029,29 @@ def test_keyed_loc_fixes(q):
         mkt[['k1', 'y']]
     with pytest.raises(KeyError):
         mkt['k1']
+
+def test_pandas_count(q):
+    tab = q('([] k1: 0n 2 0n 2 0n ; k2: (`a;`;`b;`;`c))')
+    df = tab.pd()
+
+    # Assert axis = 1
+    qcount = tab.count(axis=1).py()
+    pcount = df.count(axis=1)
+
+    print(pcount)
+    assert int(qcount[0]) == int(pcount[0])
+    assert int(qcount[1]) == 1
+
+    # Assert axis = 0
+    qcount = tab.count().py()
+    pcount = df.count()
+    
+    assert int(qcount["k1"]) == int(pcount["k1"])
+    assert int(qcount["k2"]) == 3
+
+    # Assert only numeric
+    qcount = tab.count(numeric_only = True).py()
+    pcount = df.count(numeric_only = True)
+    
+    assert int(qcount["k1"]) == int(pcount["k1"])
+


### PR DESCRIPTION
# Feature

- Please insert link to associated issue here: /issues/4

## What does this change introduce?

Add _count_ to pandas API.

Observations: 

* In accordance with the correspondence between q nulls and Python nulls established in the .pd conversion, the empty string is regarded as a null value for columns of type _symbol_. 


## General

- [ ] Has an example been added to demo the new feature?
- [ ] Have existing examples been updated or tested?
- [ ] Have you added any new Environment Variables/Configuration Options? If yes please tick the boxes below as applicable
    - [ ] Addition to reimporter logic within `src/pykx/pykx.q` and `src/pykx/reimporter.py`
    - [ ] Have updated the `src/pykx/util.py` logic which is used for environment variable
- [ ] If there have been any dependency updates have they been reflected in all files?
    - [ ] pyproject.toml
    - [ ] docs/getting-started/installing.md
    - [ ] conda-recipe/meta.yaml
    - [ ] README.md
- [ ] If any examples have been updated has it's associated `.zip` been updated

## Code

- [x] Has all temporary code used during development been removed?
- [x] Has all commented out (unused) code been removed?
- [x] Where reasonable have you ensured there is no duplication of existing code?
- [x] If applicable for your use-case have you ensured that the code is performant?

## Testing

- [x] Have unit tests been created or existing ones updated to test this new functionality?

## Documentation

- [x] Has documentation been added for all public code?
- [x] Has a release note been included for the new feature?
- [ ] Has any documentation which would benefit from this feature been updated to use the most up to date functionality?
- [ ] If a new class has been added has a documentation stub `.md` file associated with it been created?
- [ ] If any documentation page has been created has it been added to `mkdocs.yml`
- [x] Have you checked your changes with a spell checker? (US English)