### PR TITLE
Added implementation of round

### DIFF
--- a/docs/user-guide/advanced/Pandas_API.ipynb
+++ b/docs/user-guide/advanced/Pandas_API.ipynb
@@ -2261,6 +2261,68 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0c056fd9-fe7b-43d5-b1c7-7ceec3cae5ff",
+   "metadata": {},
+   "source": [
+    "### Table.round()\n",
+    "\n",
+    "```\n",
+    "Table.round(self, decimals: Union[int, Dict[str, int]] = 0)\n",
+    "```\n",
+    "\n",
+    "Round a Table to a variable number of decimal places.\n",
+    "\n",
+    "**Parameters:**\n",
+    "\n",
+    "| Name             | Type                | Description                                                   | Default |\n",
+    "| :--------------: | :-----------------: | :------------------------------------------------------------ | :-----: |\n",
+    "| decimals         | int or Dict or list | Number of decimal places to round each column to. If an int is given, round each real or float column to the same number of places. Otherwise dict rounds to variable numbers of places. Column names should be in the keys if decimals is a dict-like and the decimals to round should be the value. Any columns not included in decimals will be left as is. Elements of decimals which are not columns of the input will be ignored.| 0       |\n",
+    "\n",
+    "**Returns:**\n",
+    "\n",
+    "| Type       | Description                                                                              |\n",
+    "| :--------: | :--------------------------------------------------------------------------------------- |\n",
+    "| Table      | A Table with the affected columns rounded to the specified number of decimal places. |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b629def",
+   "metadata": {},
+   "source": [
+    "If an integer is provided it rounds every float column to set decimals."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "08c182c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tab.round(1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28853fc0",
+   "metadata": {},
+   "source": [
+    "If a dict whose keys are the column names and its values are the decimals to round set column is provided, it will round them accordingly.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7640df4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tab.round({\"price\": 1, \"traded\": 0})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cbcdf84e",
    "metadata": {},
    "source": [

--- a/docs/user-guide/advanced/Pandas_API.ipynb
+++ b/docs/user-guide/advanced/Pandas_API.ipynb
@@ -2276,7 +2276,7 @@
     "\n",
     "| Name             | Type                | Description                                                   | Default |\n",
     "| :--------------: | :-----------------: | :------------------------------------------------------------ | :-----: |\n",
-    "| decimals         | int or Dict | Number of decimal places to round each column to. If an int is given, round each real or float column to the same number of places. Otherwise dict rounds to variable numbers of places. Column names should be in the keys if decimals is a dict-like and the decimals to round should be the value. Any columns not included in decimals will be left as is. Elements of decimals which are not columns of the input will be ignored.| 0       |\n",
+    "| decimals         | int or Dict | Number of decimal places to round each column to. If an int is given, round each real or float column to the same number of places. Otherwise, dict rounds to variable numbers of places. Column names should be in the keys if decimals parameter is a dict-like and the decimals to round should be the value. Any columns not included in decimals will be left as is. Elements of decimals which are not columns of the input will be ignored.| 0       |\n",
     "\n",
     "**Returns:**\n",
     "\n",

--- a/docs/user-guide/advanced/Pandas_API.ipynb
+++ b/docs/user-guide/advanced/Pandas_API.ipynb
@@ -2276,7 +2276,7 @@
     "\n",
     "| Name             | Type                | Description                                                   | Default |\n",
     "| :--------------: | :-----------------: | :------------------------------------------------------------ | :-----: |\n",
-    "| decimals         | int or Dict or list | Number of decimal places to round each column to. If an int is given, round each real or float column to the same number of places. Otherwise dict rounds to variable numbers of places. Column names should be in the keys if decimals is a dict-like and the decimals to round should be the value. Any columns not included in decimals will be left as is. Elements of decimals which are not columns of the input will be ignored.| 0       |\n",
+    "| decimals         | int or Dict | Number of decimal places to round each column to. If an int is given, round each real or float column to the same number of places. Otherwise dict rounds to variable numbers of places. Column names should be in the keys if decimals is a dict-like and the decimals to round should be the value. Any columns not included in decimals will be left as is. Elements of decimals which are not columns of the input will be ignored.| 0       |\n",
     "\n",
     "**Returns:**\n",
     "\n",

--- a/src/pykx/pandas_api/pandas_meta.py
+++ b/src/pykx/pandas_api/pandas_meta.py
@@ -255,7 +255,7 @@ class PandasMeta:
         # {y$.Q.f[z]x}[;"F";2]' `c1
         generate_ops = q("{[d;t]({[c;d;t](({string[y][0]$.Q.f[z]x}[;t[c];d[c]]');c)}[;d;t]')key[d]}")
 
-        if type(decimals) is int:
+        if isinstance(decimals, int):
             validated = dict([(col, decimals) for col in numeric_cols])
         else:
             validated = dict([(k, v) for k, v in decimals.items() if k in numeric_cols])

--- a/src/pykx/pandas_api/pandas_meta.py
+++ b/src/pykx/pandas_api/pandas_meta.py
@@ -117,26 +117,25 @@ _type_mapping = {'c': b'kx.Char',
 
 
 # Define the mapping between the returns of kx.*Vector.t and the associated typechar
-_typenum_to_typechar_mapping = {
-                0: '',
-                1: 'b',
-                2: 'g',
-                4: 'x',
-                5: 'h',
-                6: 'i',
-                7: 'j',
-                8: 'e',
-                9: 'f',
-                10: 'c',
-                11: 's',
-                12: 'p',
-                14: 'd',
-                15: 'z',
-                16: 'n',
-                17: 'u',
-                18: 'v',
-                19: 't',
-                13: 'm'}
+_typenum_to_typechar_mapping = {0: '',
+                                1: 'b',
+                                2: 'g',
+                                4: 'x',
+                                5: 'h',
+                                6: 'i',
+                                7: 'j',
+                                8: 'e',
+                                9: 'f',
+                                10: 'c',
+                                11: 's',
+                                12: 'p',
+                                14: 'd',
+                                15: 'z',
+                                16: 'n',
+                                17: 'u',
+                                18: 'v',
+                                19: 't',
+                                13: 'm'}
 
 
 class PandasMeta:

--- a/tests/test_pandas_api.py
+++ b/tests/test_pandas_api.py
@@ -1776,24 +1776,38 @@ def test_pandas_abs(kx, q):
 
 
 def test_pandas_round(kx, q):
-    q_tab = q('([]c1:1.0 .1 .01 .001 .0001 .00001;'
-              'c2:1.0 1.888 1.02 1.999 1.0002 1.00002;'
-              'c3:til 6;'
-              'c4:0 0.11 0.22 0.33 0.44 0.55e;'
-              'c5:`a`b`c`d`e`f)')
-    pd_tab = q_tab.pd()
-    round_dict = {'c1': 0, 'c2': 2}
+    q_tab = q('([]c1:4 5 10 15 20 25h;'
+              'c2:4 5 10 15 20 25i;'
+              'c3:4 5 10 15 20 25j;'
+              'c4:0 0.10 0.25 0.30 0.45 0.50e;'
+              'c5:0 0.10 0.25 0.30 0.45 0.50f;'
+              'c6:`a`b`c`d`e`f)')
+    p_tab = q_tab.pd()
 
-    assert all(pd_tab.round() == q_tab.round().pd())
-    assert all(q_tab.round(0).pd() == q_tab.round().pd())
-    assert all(pd_tab.round(2) == q_tab.round(2).pd())
-    assert all(pd_tab.round(round_dict) == q_tab.round(round_dict).pd())
+    pd.testing.assert_frame_equal(p_tab.round(),
+                                  q_tab.round().pd())
 
-    round_dict_non_numerical = {'c1': 0, 'c3': 2, 'c5': 2}
-    assert all(pd_tab.round(round_dict_non_numerical) == q_tab.round(round_dict_non_numerical).pd())
+    pd.testing.assert_frame_equal(q_tab.round(0).pd(),
+                                  q_tab.round().pd())
 
-    round_dict_real = {'c1': 0, 'c4': 1}
-    assert all(pd_tab.round(round_dict_real) == q_tab.round(round_dict_real).pd())
+    pd.testing.assert_frame_equal(p_tab.round(2),
+                                  q_tab.round(2).pd())
+
+    pd.testing.assert_frame_equal(p_tab.round(-1),
+                                  q_tab.round(-1).pd())
+
+    dict_test = {'c1': -2,
+                 'c2': -1,
+                 'c3': -0,
+                 'c4':  1,
+                 'c5':  2,
+                 'c6':  3,
+                 'c7':  4}
+
+    q_res = q_tab.round(dict_test)
+    pd.testing.assert_frame_equal(p_tab.round(dict_test), q_res.pd())
+
+    pd.testing.assert_frame_equal(q_tab.dtypes.pd(), q_res.dtypes.pd())
 
 
 def test_pandas_min(q):

--- a/tests/test_pandas_api.py
+++ b/tests/test_pandas_api.py
@@ -1774,6 +1774,7 @@ def test_pandas_abs(kx, q):
     with pytest.raises(kx.QError):
         tab.abs()
 
+
 def test_pandas_round(kx, q):
     q_tab = q('([]c1:1.0 .1 .01 .001 .0001 .00001;'
               'c2:1.0 1.888 1.02 1.999 1.0002 1.00002;'
@@ -1793,6 +1794,7 @@ def test_pandas_round(kx, q):
 
     round_dict_real = {'c1': 0, 'c4': 1}
     assert all(pd_tab.round(round_dict_real) == q_tab.round(round_dict_real).pd())
+
 
 def test_pandas_min(q):
     tab = q('([] sym: 100?`foo`bar`baz`qux; price: 250.0f - 100?500.0f; ints: 100 - 100?200)')

--- a/tests/test_pandas_api.py
+++ b/tests/test_pandas_api.py
@@ -1774,6 +1774,25 @@ def test_pandas_abs(kx, q):
     with pytest.raises(kx.QError):
         tab.abs()
 
+def test_pandas_round(kx, q):
+    q_tab = q('([]c1:1.0 .1 .01 .001 .0001 .00001;'
+              'c2:1.0 1.888 1.02 1.999 1.0002 1.00002;'
+              'c3:til 6;'
+              'c4:0 0.11 0.22 0.33 0.44 0.55e;'
+              'c5:`a`b`c`d`e`f)')
+    pd_tab = q_tab.pd()
+    round_dict = {'c1': 0, 'c2': 2}
+
+    assert all(pd_tab.round() == q_tab.round().pd())
+    assert all(q_tab.round(0).pd() == q_tab.round().pd())
+    assert all(pd_tab.round(2) == q_tab.round(2).pd())
+    assert all(pd_tab.round(round_dict) == q_tab.round(round_dict).pd())
+
+    round_dict_non_numerical = {'c1': 0, 'c3': 2, 'c5': 2}
+    assert all(pd_tab.round(round_dict_non_numerical) == q_tab.round(round_dict_non_numerical).pd())
+
+    round_dict_real = {'c1': 0, 'c4': 1}
+    assert all(pd_tab.round(round_dict_real) == q_tab.round(round_dict_real).pd())
 
 def test_pandas_min(q):
     tab = q('([] sym: 100?`foo`bar`baz`qux; price: 250.0f - 100?500.0f; ints: 100 - 100?200)')


### PR DESCRIPTION
Provides an implementation for the `round` method.

Solves: /issues/13

**Parameters:**

| Name             | Type                | Description                                                   | Default |
| :--------------: | :-----------------: | :------------------------------------------------------------ | :-----: |
| decimals         | int or Dict | Number of decimal places to round each column to. If an int is given, round each real or float column to the same number of places. Otherwise dict rounds to variable numbers of places. Column names should be in the keys if decimals is a dict-like and the decimals to round should be the value. Any columns not included in decimals will be left as is. Elements of decimals which are not columns of the input will be ignored.| 0       |

**Returns:**

| Type       | Description                                                                              |
| :--------: | :--------------------------------------------------------------------------------------- |
| Table      | A Table with the affected columns rounded to the specified number of decimal places. |

It follows the [pandas definition](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.round.html), but it ignores the `pd.Series` type for the `decimals` parameter. This is because as it can be seen in the usage examples, this Series can be more easily be represented using a dictionary.
