### PR TITLE
Feature/pandas api isnull

### DIFF
--- a/docs/user-guide/advanced/Pandas_API.ipynb
+++ b/docs/user-guide/advanced/Pandas_API.ipynb
@@ -2337,6 +2337,107 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5e21bef1",
+   "metadata": {},
+   "source": [
+    "### Table.isna()\n",
+    "\n",
+    "```\n",
+    "Table.isna()\n",
+    "```\n",
+    "\n",
+    "Detects null values on a Table object.\n",
+    "\n",
+    "**Parameters:**\n",
+    "\n",
+    "\n",
+    "**Returns:**\n",
+    "\n",
+    "| Type               | Description                                                          |\n",
+    "| :----------------: | :------------------------------------------------------------------- |\n",
+    "| Table         | A Table with the same shape as the original but containing boolean values. 1b represents a null value was on its place and 0b represents the opposite |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8ff16e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tab.isna()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47d20b00",
+   "metadata": {},
+   "source": [
+    "### Table.isnull()\n",
+    "\n",
+    "```\n",
+    "Table.isnull()\n",
+    "```\n",
+    "\n",
+    "Alias of Table.isna().\n",
+    "Detects null values on a Table object.\n",
+    "\n",
+    "**Parameters:**\n",
+    "\n",
+    "\n",
+    "**Returns:**\n",
+    "\n",
+    "| Type               | Description                                                          |\n",
+    "| :----------------: | :------------------------------------------------------------------- |\n",
+    "| Table         | A Table with the same shape as the original but containing boolean values. 1b represents a null value was on its place and 0b represents the opposite |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "400c209e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tab.isnull()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb3164d5",
+   "metadata": {},
+   "source": [
+    "### Table.notna()\n",
+    "\n",
+    "```\n",
+    "Table.notna()\n",
+    "```\n",
+    "\n",
+    "Boolean inverse of Table.isna().\n",
+    "Detects non-null values on a Table object.\n",
+    "\n",
+    "**Parameters:**\n",
+    "\n",
+    "\n",
+    "**Returns:**\n",
+    "\n",
+    "| Type               | Description                                                          |\n",
+    "| :----------------: | :------------------------------------------------------------------- |\n",
+    "| Table         | A Table with the same shape as the original but containing boolean values. 1b represents a non null value was on its place and 0b represents the opposite |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4206eec3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tab.notna()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a3c3fccd",
    "metadata": {},
    "source": [

--- a/docs/user-guide/advanced/Pandas_API.ipynb
+++ b/docs/user-guide/advanced/Pandas_API.ipynb
@@ -2380,6 +2380,7 @@
     "```\n",
     "\n",
     "Alias of Table.isna().\n",
+    "\n",
     "Detects null values on a Table object.\n",
     "\n",
     "**Parameters:**\n",
@@ -2414,6 +2415,7 @@
     "```\n",
     "\n",
     "Boolean inverse of Table.isna().\n",
+    "\n",
     "Detects non-null values on a Table object.\n",
     "\n",
     "**Parameters:**\n",
@@ -2434,6 +2436,41 @@
    "outputs": [],
    "source": [
     "tab.notna()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e8e5c07",
+   "metadata": {},
+   "source": [
+    "### Table.notnull()\n",
+    "\n",
+    "```\n",
+    "Table.notna()\n",
+    "```\n",
+    "\n",
+    "Boolean inverse of Table.isnull(). Alias of Table.isna()\n",
+    "\n",
+    "Detects non-null values on a Table object.\n",
+    "\n",
+    "**Parameters:**\n",
+    "\n",
+    "\n",
+    "**Returns:**\n",
+    "\n",
+    "| Type               | Description                                                          |\n",
+    "| :----------------: | :------------------------------------------------------------------- |\n",
+    "| Table         | A Table with the same shape as the original but containing boolean values. 1b represents a non null value was on its place and 0b represents the opposite. |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3138d21a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tab.notnull()"
    ]
   },
   {

--- a/docs/user-guide/advanced/Pandas_API.ipynb
+++ b/docs/user-guide/advanced/Pandas_API.ipynb
@@ -2355,7 +2355,7 @@
     "\n",
     "| Type               | Description                                                          |\n",
     "| :----------------: | :------------------------------------------------------------------- |\n",
-    "| Table         | A Table with the same shape as the original but containing boolean values. 1b represents a null value was on its place and 0b represents the opposite |"
+    "| Table         | A Table with the same shape as the original but containing boolean values. 1b represents a null value was on its place and 0b represents the opposite. |"
    ]
   },
   {
@@ -2389,7 +2389,7 @@
     "\n",
     "| Type               | Description                                                          |\n",
     "| :----------------: | :------------------------------------------------------------------- |\n",
-    "| Table         | A Table with the same shape as the original but containing boolean values. 1b represents a null value was on its place and 0b represents the opposite |"
+    "| Table         | A Table with the same shape as the original but containing boolean values. 1b represents a null value was on its place and 0b represents the opposite. |"
    ]
   },
   {
@@ -2423,7 +2423,7 @@
     "\n",
     "| Type               | Description                                                          |\n",
     "| :----------------: | :------------------------------------------------------------------- |\n",
-    "| Table         | A Table with the same shape as the original but containing boolean values. 1b represents a non null value was on its place and 0b represents the opposite |"
+    "| Table         | A Table with the same shape as the original but containing boolean values. 1b represents a non null value was on its place and 0b represents the opposite. |"
    ]
   },
   {
@@ -2461,7 +2461,7 @@
     "\n",
     "| Type               | Description                                                          |\n",
     "| :----------------: | :------------------------------------------------------------------- |\n",
-    "| Dictionary         | A dictionary where the key represent the column name / row number and the values are the result of calling `max` on that column / row. |"
+    "| Dictionary         | A dictionary where the key represent the column name / row number and the values are the result of calling `max` on that column / row.  |"
    ]
   },
   {

--- a/src/pykx/pandas_api/pandas_meta.py
+++ b/src/pykx/pandas_api/pandas_meta.py
@@ -313,16 +313,16 @@ class PandasMeta:
             return (q('{(flip enlist[`function]!enlist x)!y}', keyname, data))
 
     @api_return
-    def isnull(self):
+    def isna(self):
         tab = self
         return q.null(tab)
 
     @api_return
-    def isnan(self):
+    def isnull(self):
         tab = self
-        return tab.isnull()
+        return tab.isna()
 
     @api_return
     def notna(self):
         tab = self
-        return q('not', tab.isnull())
+        return q('not', tab.isna())

--- a/src/pykx/pandas_api/pandas_meta.py
+++ b/src/pykx/pandas_api/pandas_meta.py
@@ -314,15 +314,16 @@ class PandasMeta:
 
     @api_return
     def isna(self):
-        tab = self
-        return q.null(tab)
+        return q.null(self)
 
     @api_return
     def isnull(self):
-        tab = self
-        return tab.isna()
+        return self.isna()
 
     @api_return
     def notna(self):
-        tab = self
-        return q('not', tab.isna())
+        return q('not', self.isna())
+
+    @api_return
+    def notnull(self):
+        return self.notna()

--- a/src/pykx/pandas_api/pandas_meta.py
+++ b/src/pykx/pandas_api/pandas_meta.py
@@ -311,3 +311,18 @@ class PandasMeta:
             return data
         else:
             return (q('{(flip enlist[`function]!enlist x)!y}', keyname, data))
+
+    @api_return
+    def isnull(self):
+        tab = self
+        return q.null(tab)
+
+    @api_return
+    def isnan(self):
+        tab = self
+        return tab.isnull()
+
+    @api_return
+    def notna(self):
+        tab = self
+        return q('not', tab.isnull())

--- a/tests/test_pandas_api.py
+++ b/tests/test_pandas_api.py
@@ -2030,6 +2030,7 @@ def test_keyed_loc_fixes(q):
     with pytest.raises(KeyError):
         mkt['k1']
 
+
 def test_isnull(q):
     tab = q('''([]
         g:1#0Ng;    h:1#0Nh;    i1:1#0Ni; j:1#0Nj;
@@ -2041,7 +2042,7 @@ def test_isnull(q):
         m2:1?"m"$10;d2:1?"d"$10;n2:1?10n; u2:1?10u;
         v2:1?10v;   t2:1?10t;   c2:1?" ")
         ''')
-    
+
     expected = q('''([]
         g: 1#1b;h: 1#1b;i1:1#1b;j: 1#1b;
         e: 1#1b;f: 1#1b;s: 1#1b;p: 1#1b;
@@ -2053,7 +2054,7 @@ def test_isnull(q):
         v2:1#0b;t2:1#0b;c2:1#0b)
         ''')
 
-    assert (tab.isna()   == expected).all().all()
+    assert (tab.isna() == expected).all().all()
     assert (tab.isnull() == expected).all().all()
-    assert (tab.notna()  == q("not", expected)).all().all()
-    
+    assert (tab.notna() == q("not", expected)).all().all()
+

--- a/tests/test_pandas_api.py
+++ b/tests/test_pandas_api.py
@@ -2057,4 +2057,3 @@ def test_isnull(q):
     assert (tab.isna() == expected).all().all()
     assert (tab.isnull() == expected).all().all()
     assert (tab.notna() == q("not", expected)).all().all()
-

--- a/tests/test_pandas_api.py
+++ b/tests/test_pandas_api.py
@@ -2043,17 +2043,20 @@ def test_isnull(q):
         v2:1?10v;   t2:1?10t;   c2:1?" ")
         ''')
 
-    expected = q('''([]
-        g: 1#1b;h: 1#1b;i1:1#1b;j: 1#1b;
-        e: 1#1b;f: 1#1b;s: 1#1b;p: 1#1b;
-        m: 1#1b;d: 1#1b;n: 1#1b;u: 1#1b;
-        v: 1#1b;t: 1#1b;c: 1#1b;
-        g2:1#0b;h2:1#0b;i2:1#0b;j2:1#0b;
-        e2:1#0b;f2:1#0b;s2:1#0b;p2:1#0b;
-        m2:1#0b;d2:1#0b;n2:1#0b;u2:1#0b;
-        v2:1#0b;t2:1#0b;c2:1#0b)
-        ''')
+    cols = ["g", "h", "i1", "j",
+            "e", "f", "s", "p",
+            "m", "d", "n", "u",
+            "v", "t", "c",
+            "g2", "h2", "i2", "j2",
+            "e2", "f2", "s2", "p2",
+            "m2", "d2", "n2", "u2",
+            "v2", "t2", "c2"]
 
-    assert (tab.isna() == expected).all().all()
-    assert (tab.isnull() == expected).all().all()
-    assert (tab.notna() == q("not", expected)).all().all()
+    expected = pd.DataFrame.from_dict({c: [True] if i < 15 else [False]
+                                       for i, c in enumerate(cols)})
+    expected_inv = ~expected
+
+    pd.testing.assert_frame_equal(tab.isna().pd(), expected)
+    pd.testing.assert_frame_equal(tab.isnull().pd(), expected)
+    pd.testing.assert_frame_equal(tab.notna().pd(), expected_inv)
+    pd.testing.assert_frame_equal(tab.notnull().pd(), expected_inv)

--- a/tests/test_pandas_api.py
+++ b/tests/test_pandas_api.py
@@ -2031,17 +2031,29 @@ def test_keyed_loc_fixes(q):
         mkt['k1']
 
 def test_isnull(q):
-    tab = q('''([]g:3#0Ni;h:3#0Nh;in:3#0Ni;j:3#0Nj;
-                  e:3#0Ne;f:3#0Nf;s: 3#`  ;p:3#0Np;
-                  m:3#0Nm;d:3#0Nd;n: 3#0Nn;
-                  u:3#0Nu;v:3#0Nv;t: 3#0Nt;c:3#" ")''')
-    assert all(tab.isnull())
-    assert all(tab.isna())
-    assert all(tab.notna())
+    tab = q('''([]
+        g:1#0Ng;    h:1#0Nh;    i1:1#0Ni; j:1#0Nj;
+        e:1#0Ne;    f:1#0Nf;    s:1#`  ;  p:1#0Np;
+        m:1#0Nm;    d:1#0Nd;    n:1#0Nn;  u:1#0Nu;
+        v:1#0Nv;    t:1#0Nt;    c:1#" ";
+        g2:1?0Ng;   h2:1?0Wh;   i2:1?10i; j2:1?10j;
+        e2:1?10e;   f2:1?10f;   s2:1#`foo;p2:1?10p;
+        m2:1?"m"$10;d2:1?"d"$10;n2:1?10n; u2:1?10u;
+        v2:1?10v;   t2:1?10t;   c2:1?" ")
+        ''')
     
-    tab_pd = tab.pd()
-    assert pd.testing.assert_frame_equal(tab.isnull().pd(), tab_pd.isnull())
-    assert pd.testing.assert_frame_equal(tab.isna().pd(), tab_pd.isna())
-    assert pd.testing.assert_frame_equal(tab.notna().pd(), tab_pd.notna())
-    
+    expected = q('''([]
+        g: 1#1b;h: 1#1b;i1:1#1b;j: 1#1b;
+        e: 1#1b;f: 1#1b;s: 1#1b;p: 1#1b;
+        m: 1#1b;d: 1#1b;n: 1#1b;u: 1#1b;
+        v: 1#1b;t: 1#1b;c: 1#1b;
+        g2:1#0b;h2:1#0b;i2:1#0b;j2:1#0b;
+        e2:1#0b;f2:1#0b;s2:1#0b;p2:1#0b;
+        m2:1#0b;d2:1#0b;n2:1#0b;u2:1#0b;
+        v2:1#0b;t2:1#0b;c2:1#0b)
+        ''')
+
+    assert (tab.isna()   == expected).all().all()
+    assert (tab.isnull() == expected).all().all()
+    assert (tab.notna()  == q("not", expected)).all().all()
     

--- a/tests/test_pandas_api.py
+++ b/tests/test_pandas_api.py
@@ -2029,3 +2029,19 @@ def test_keyed_loc_fixes(q):
         mkt[['k1', 'y']]
     with pytest.raises(KeyError):
         mkt['k1']
+
+def test_isnull(q):
+    tab = q('''([]g:3#0Ni;h:3#0Nh;in:3#0Ni;j:3#0Nj;
+                  e:3#0Ne;f:3#0Nf;s: 3#`  ;p:3#0Np;
+                  m:3#0Nm;d:3#0Nd;n: 3#0Nn;
+                  u:3#0Nu;v:3#0Nv;t: 3#0Nt;c:3#" ")''')
+    assert all(tab.isnull())
+    assert all(tab.isna())
+    assert all(tab.notna())
+    
+    tab_pd = tab.pd()
+    assert pd.testing.assert_frame_equal(tab.isnull().pd(), tab_pd.isnull())
+    assert pd.testing.assert_frame_equal(tab.isna().pd(), tab_pd.isna())
+    assert pd.testing.assert_frame_equal(tab.notna().pd(), tab_pd.notna())
+    
+    


### PR DESCRIPTION
Adds an implementation for the `isnull()`, `isna()`, `notnull()` and `notna()` methods following their pandas definition:

Closes /issues/26

- https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.isnull.html#pandas.DataFrame.isnull
- https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.isna.html#pandas.DataFrame.isna
- https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.notnull.html#pandas.DataFrame.notnull
- https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.notna.html#pandas.DataFrame.notna

